### PR TITLE
feat(bashrc): add vim as editor

### DIFF
--- a/container-setup/bashrc_supplement.sh
+++ b/container-setup/bashrc_supplement.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+export EDITOR=vim
+
 source /usr/local/kube_ps1/kube-ps1.sh
 export PS1='[\u@\h \W $(ocm_environment) $(kube_ps1)]\$ '
 export KUBE_PS1_BINARY=oc


### PR DESCRIPTION
 when running `oc edit` the default editor is used, now `vim` will be used