### PR TITLE
fix(install.sh): make moactl installation via go-get

### DIFF
--- a/container-setup/install.sh
+++ b/container-setup/install.sh
@@ -27,10 +27,8 @@ yum clean all;
 
 mkdir /usr/local/moactl;
 pushd /usr/local/moactl;
-wget -q https://github.com/openshift/moactl/releases/download/${moactlversion}/moactl-linux-amd64;
-mv moactl{-linux-amd64,}
-chmod +x moactl
-ln -s /usr/local/moactl/moactl /usr/local/bin/moactl;
+go get -v -u github.com/openshift/moactl;
+ln -s /root/go/bin/moactl /usr/local/bin/moactl;
 moactl completion bash >  /etc/bash_completion.d/moactl
 popd;
 


### PR DESCRIPTION
now that moactl can be installed via go-get, I don't see a reason not to use it