### PR TITLE
fix(ocm-container.sh): docker absolute path

### DIFF
--- a/ocm-container.sh
+++ b/ocm-container.sh
@@ -19,7 +19,7 @@ source ${OCM_CONTAINER_CONFIG}
 ${CONTAINER_SUBSYS} run -it --rm --privileged \
 -e "OCM_URL=${OCM_URL}" \
 -e "SSH_AUTH_SOCK=/tmp/ssh.sock" \
--v ./env.source:/root/env.source \
+-v $(pwd)/env.source:/root/env.source \
 -v ${SSH_AUTH_SOCK}:/tmp/ssh.sock \
 -v ${HOME}/.ssh:/root/.ssh \
 ocm-container /bin/bash ## -c "/container-setup/login.sh $@ && /container-setup/bash-ps1-wrap.sh"


### PR DESCRIPTION
the error:

'docker: Error response from daemon: create ./env.source: \
./env.source includes invalid characters for a local volume name, \
only [a-zA-Z0-9][a-zA-Z0-9_.-] are allowed. \
If you intended to pass a host directory, use absolute path.'

requires an absolute path for running 'ocm-container.sh'