### PR TITLE
feat(login.sh): private cluster support

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ Config:
 * optional: configure alias in `~/.bashrc`
   * alias ocm-container="/path/to/ocm-container/ocm-container.sh"
   * alias ocm-container-stg="OCM_URL=staging /path/to/ocm-container/ocm-container.sh"
+  * FOR mac users you might need to prepend the `SSH_AUTH_ENABLE=ssh-agent`
+    * alias ocm-container="SSH_AUTH_ENABLE=ssh-agent /path/to/ocm-container/ocm-container.sh"
+    * alias ocm-container-stg="SSH_AUTH_ENABLE=ssh-agent OCM_URL=staging /path/to/ocm-container/ocm-container.sh"
 
 Build:
 
@@ -82,3 +85,10 @@ vim ~/.bashrc
 alias ocm-container='/path/to/ocm-container/ocm-container.sh'
 alias ocm-container-stg='OCM_URL=staging /path/to/ocm-container/ocm-container.sh'
 ```
+
+# Private clusters
+the tool makes it easier to login to the private clusters, when you use the container-setup/login.sh command
+with the clusterID, you only need to:
+- copy the `shuttle` command to another terminal
+- grab the token
+- run the login.sh command again and use it to log in

--- a/container-setup/login.sh
+++ b/container-setup/login.sh
@@ -35,9 +35,20 @@ if [ "${CLUSTERID}" != "" ]; then
     CLUSTER_DATA=$("${CLI}" describe cluster ${CLUSTERID} --json || exit )
     CLUSTER_API_TYPE=$( echo ${CLUSTER_DATA} | jq --raw-output .api.listening )
     CONSOLE_URL=$(echo ${CLUSTER_DATA} | jq --raw-output .console.url)
+    if [[ ${CONSOLE_URL} == "null" ]]
+    then
+	    echo "FAILURE: console url is not yet exposed, please wait"
+	    exit 1
+    fi
+
     if [[ ${CLUSTER_API_TYPE} == "internal" ]]
     then
-            echo "FAILURE: cannot connect to a private cluster"
+            echo "INFO: requested ${CLUSTERID} is private"
+	    echo "attempting to tunnel connection across, prerequisites are located in https://github.com/openshift/ops-sop/blob/master/v4/howto/private-clusters.md"
+	    echo
+	    ssh-add
+	    echo "to tunnel your connection to the cluster, run:"
+	    echo "$ ocm tunnel -c '${CLUSTERID}' &"
     fi
 
     "${CLI}" cluster login ${CLUSTERID} --username ${OCM_USER} --console >/dev/null 2>&1 \

--- a/env.source.sample
+++ b/env.source.sample
@@ -13,6 +13,10 @@ export CONTAINER_SUBSYS="sudo docker"
 ### defaults to "ocm"
 export CLI=${CLI:-}
 
+### The toggle to run the ssh-agent inside the container
+### to enale set it to 'ssh-agent'
+export SSH_AUTH_ENABLE=${SSH_AUTH_ENABLE:-}
+
 ### The Url in which you want your ocm queries to go to
 ### you can use 'staging' or 'integration'
 ###

--- a/ocm-container.sh
+++ b/ocm-container.sh
@@ -22,5 +22,5 @@ ${CONTAINER_SUBSYS} run -it --rm --privileged \
 -v $(pwd)/env.source:/root/env.source \
 -v ${SSH_AUTH_SOCK}:/tmp/ssh.sock \
 -v ${HOME}/.ssh:/root/.ssh \
-ocm-container /bin/bash ## -c "/container-setup/login.sh $@ && /container-setup/bash-ps1-wrap.sh"
+ocm-container ${SSH_AUTH_ENABLE} /bin/bash ## -c "/container-setup/login.sh $@ && /container-setup/bash-ps1-wrap.sh"
 


### PR DESCRIPTION
you can now run 'login.sh' on a private cluster and all the required information will be displayed