### PR TITLE
Simplifies Initialization and adds customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ Related tools added to image:
 
 * clone this repo
 * `./init.sh`
-* edit the file `$HOME/.config/ocm-env/env.source`
+* edit the file `$HOME/.config/ocm-container/env.source`
   * set your requested OCM_USER (for `ocm -u OCM_USER`)
   * set your OFFLINE_ACCESS_TOKEN (from [cloud.redhat.com](https://cloud.redhat.com/))
 * optional: configure alias in `~/.bashrc`
-  * alias ocm-env-stg="OCM_URL=staging ocm-env"
+  * alias ocm-container-stg="OCM_URL=staging ocm-container"
 
 ### Build:
 
@@ -34,7 +34,7 @@ Related tools added to image:
 
 ### Use it:
 ```
-ocm-env
+ocm-container
 ```
 
 ## Example:
@@ -42,7 +42,7 @@ ocm-env
 ### Public Clusters
 
 ```
-$ ocm-env
+$ ocm-container
 [production] # ./login.sh
 [production] # ocm cluster login test-cluster
 Will login to cluster:
@@ -64,7 +64,7 @@ Welcome! See 'oc help' to get started.
 This tool also can tunnel into private clusters.
 
 ```
-$ ocm-env-stg
+$ ocm-container-stg
 [staging] # ./login.sh
 [staging] # ocm tunnel --cluster test-cluster -- --dns
 Will create tunnel to cluster:

--- a/README.md
+++ b/README.md
@@ -6,61 +6,45 @@ Related tools added to image:
 * `ocm`
 * `oc`
 * `aws`
+* `osdctl`
 
-Features:
+## Features:
 * Does not mount any host filesystem objects as read/write, only uses read-only mounts.
 * Uses ephemeral containers per cluster login, keeping seperate `.kube` configuration and credentials.
 * Credentials are destroyed on container exit (container has `--rm` flag set)
 * Displays current cluster-name, and OpenShift project (`oc project`) in bash PS1
 
-## Usage:
+## Getting Started:
 
-Config:
+### Config:
 
-* cp env.source.sample env.source
-* vim env.source
+* clone this repo
+* `./init.sh`
+* `vim $HOME/.config/ocm-env/env.source`
   * set your requested OCM_USER (for `ocm -u OCM_USER`)
   * set your OFFLINE_ACCESS_TOKEN (from [cloud.redhat.com](https://cloud.redhat.com/))
 * optional: configure alias in `~/.bashrc`
-  * alias ocm-container="/path/to/ocm-container/ocm-container.sh"
-  * alias ocm-container-stg="OCM_URL=staging /path/to/ocm-container/ocm-container.sh"
-  * FOR mac users you might need to prepend the `SSH_AUTH_ENABLE=ssh-agent`
-    * alias ocm-container="SSH_AUTH_ENABLE=ssh-agent /path/to/ocm-container/ocm-container.sh"
-    * alias ocm-container-stg="SSH_AUTH_ENABLE=ssh-agent OCM_URL=staging /path/to/ocm-container/ocm-container.sh"
+  * alias ocm-env-stg="OCM_URL=staging ocm-env"
 
-Build:
+### Build:
 
 ```
 ./build.sh
 ```
 
-* Check current `oc` version from here, can use force version by specifyng filename in environment variable `osv4client`:
-[mirror.openshift.com](https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/)
-
-Usage:
-
+### Use it:
 ```
-# Bootstrap ocm-container environment
-./ocm-container.sh
-
-
-## In-container
-
-# Get a list of clusters.
-./login.sh
-
-# Login to cluster
-./login.sh <cluster_name>
-
-# Multiple logins to multiple clusters
-# Just open multiple containers, one container per login
+ocm-env
 ```
 
-Example:
+## Example:
+
+### Public Clusters
 
 ```
-./ocm-container.sh
-./login.sh test-cluster
+$ ocm-env
+[production] # ./login.sh
+[production] # ocm cluster login test-cluster
 Will login to cluster:
  Name: test-cluster
  ID: 01234567890123456789012345678901
@@ -73,22 +57,42 @@ You have access to 67 projects, the list has been suppressed. You can list all p
 
 Using project "default".
 Welcome! See 'oc help' to get started.
-[root@999999999999 /] (test-cluster)#
+[production] (test-cluster) #
 ```
 
-Bash Alias:
-
-Enables access from anywhere on the filesystem.
+### Private clusters
+This tool also can tunnel into private clusters.
 
 ```
-vim ~/.bashrc
-alias ocm-container='/path/to/ocm-container/ocm-container.sh'
-alias ocm-container-stg='OCM_URL=staging /path/to/ocm-container/ocm-container.sh'
+$ ocm-env-stg
+[staging] # ./login.sh
+[staging] # ocm tunnel --cluster test-cluster -- --dns
+Will create tunnel to cluster:
+ Name: test-cluster
+ ID: 01234567890123456789012345678901
+
+# /usr/bin/sshuttle --remote sre-user@ssh-url.test-cluster.mycluster.com 10.0.0.0/16 172.31.0.0/16 --dns
+client: Connected.
+^Z
+[1]+  Stopped     ocm tunnel --cluster test-cluster -- --dns
+[staging] # bg 1
+[1]+ ocm tunnel --cluster test-cluster -- --dns &
+[staging] # ocm cluster login test-cluster --console
+Will login to cluster:
+ Name: test-cluster
+ ID: 01234567890123456789012345678901
+ Console URL: https://console.apps.test-cluster.mycluster.com
+[staging] # oc login --token AAABBBCCCDDDEEEFFFGGGHHH myuser@api.apps.test-cluster.mycluster.com
+Login successful.
+
+You have access to 67 projects, the list has been suppressed. You can list all projects with 'oc projects'
+
+Using project "default".
+Welcome! See 'oc help' to get started.
+[staging] (test-cluster) #
 ```
 
-# Private clusters
-the tool makes it easier to login to the private clusters, when you use the container-setup/login.sh command
 with the clusterID, you only need to:
-- copy the `shuttle` command to another terminal
+- copy the `sshuttle` command to another terminal
 - grab the token
-- run the login.sh command again and use it to log in
+- run the ocm cluster login command again and use it to log in

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Related tools added to image:
 
 * clone this repo
 * `./init.sh`
-* `vim $HOME/.config/ocm-env/env.source`
+* edit the file `$HOME/.config/ocm-env/env.source`
   * set your requested OCM_USER (for `ocm -u OCM_USER`)
   * set your OFFLINE_ACCESS_TOKEN (from [cloud.redhat.com](https://cloud.redhat.com/))
 * optional: configure alias in `~/.bashrc`

--- a/build.sh
+++ b/build.sh
@@ -4,16 +4,16 @@
 cd $(dirname $0)
 
 ### Load config
-export OCM_CONTAINER_CONFIG="./env.source"
+export OCM_ENV_CONFIG="${HOME}/.config/ocm-env/env.source"
 
 export CONTAINER_SUBSYS="sudo docker"
 
-if [ ! -f ${OCM_CONTAINER_CONFIG} ]; then
+if [ ! -f ${OCM_ENV_CONFIG} ]; then
     echo "Cannot find config file, exiting";
     exit 1;
 fi
 
-source ${OCM_CONTAINER_CONFIG}
+source ${OCM_ENV_CONFIG}
 
 ### Select osv4client version, auto-detect from mirror.openshift.com
 if [ "x${osv4client}" == "x" ]; then

--- a/build.sh
+++ b/build.sh
@@ -4,16 +4,16 @@
 cd $(dirname $0)
 
 ### Load config
-export OCM_ENV_CONFIG="${HOME}/.config/ocm-env/env.source"
+export OCM_CONTAINER_CONFIG="${HOME}/.config/ocm-container/env.source"
 
 export CONTAINER_SUBSYS="sudo docker"
 
-if [ ! -f ${OCM_ENV_CONFIG} ]; then
+if [ ! -f ${OCM_CONTAINER_CONFIG} ]; then
     echo "Cannot find config file, exiting";
     exit 1;
 fi
 
-source ${OCM_ENV_CONFIG}
+source ${OCM_CONTAINER_CONFIG}
 
 ### Select osv4client version, auto-detect from mirror.openshift.com
 if [ "x${osv4client}" == "x" ]; then

--- a/container-setup/bashrc_supplement.sh
+++ b/container-setup/bashrc_supplement.sh
@@ -4,12 +4,12 @@ source /usr/local/kube_ps1/kube-ps1.sh
 
 ## Set Defaults
 export EDITOR=vim
-export PS1='[\u@\h \W $(ocm_environment) $(kube_ps1)]\$ '
+export PS1='[\W $(ocm_environment) $(kube_ps1)]\$ '
 export KUBE_PS1_BINARY=oc
 export KUBE_PS1_CLUSTER_FUNCTION=cluster_function
 export KUBE_PS1_SYMBOL_ENABLE=false
 ## Overwrite defaults with user-config
-source /root/.config/ocm-env/env.source
+source /root/.config/ocm-container/env.source
 
 
 complete -C '/usr/local/aws/aws/dist/aws_completer' aws

--- a/container-setup/bashrc_supplement.sh
+++ b/container-setup/bashrc_supplement.sh
@@ -1,12 +1,17 @@
 #!/bin/bash
 
-export EDITOR=vim
-
 source /usr/local/kube_ps1/kube-ps1.sh
+
+## Set Defaults
+export EDITOR=vim
 export PS1='[\u@\h \W $(ocm_environment) $(kube_ps1)]\$ '
 export KUBE_PS1_BINARY=oc
 export KUBE_PS1_CLUSTER_FUNCTION=cluster_function
 export KUBE_PS1_SYMBOL_ENABLE=false
+## Overwrite defaults with user-config
+source /root/.config/ocm-env/env.source
+
+
 complete -C '/usr/local/aws/aws/dist/aws_completer' aws
 
 function cluster_function() {

--- a/container-setup/install.sh
+++ b/container-setup/install.sh
@@ -28,7 +28,4 @@ echo "Installing osdctl"
 echo "Installing Velero"
 ./install-velero.sh
 
-# Activate all environment variables from env.source
-echo 'source /root/env.source' >> ~/.bashrc
-
-echo 'source /container-setup/bashrc_supplement.sh' >> ~/.bashrc
+cat /container-setup/bashrc_supplement.sh >> ~/.bashrc

--- a/init.sh
+++ b/init.sh
@@ -1,27 +1,59 @@
 #!/bin/bash
 
 cd $(dirname $0)
+CONFIG_DIR=${HOME}/.config/ocm-container
 
-CONFIG_DIR=${HOME}/.config/ocm-env
+function init_new_config() {
+  if [ ! -f ${CONFIG_DIR}/env.source ]
+  then
+    echo "Initializing Default Configuration"
+    cp env.source.sample ${CONFIG_DIR}/env.source
+  else
+    echo "ocm-container is already configured."
+  fi
+}
+
 mkdir -p ${CONFIG_DIR}
 
-if [ ! -f ${CONFIG_DIR}/env.source ]
+if [ -f env.source ]
 then
-  echo "Initializing Default Configuration"
-  cp env.source.sample ${CONFIG_DIR}/env.source
+  echo "We see you already have a local configuration file.  Would you like us to:"
+  echo "  1: Move the config file to the new config location"
+  echo "  2: Symlink the config file to the new config location"
+  echo "  3: Create a new config file at the new config location"
+  echo "  4: Do nothing and exit"
+  read -n 1 -p "Select 1-4: " prev_config_selection
+  echo
+
+  if [ $prev_config_selection == "1" ]
+  then
+    echo "Moving configuration file"
+    mv env.source ${CONFIG_DIR}
+  elif [ $prev_config_selection == "2" ]
+  then
+    echo "Symlinking configuration file"
+    ln -s env.source $CONFIG_DIR/env.source
+  elif [ $prev_config_selection == "3" ]
+  then
+    init_new_config
+  else
+    echo "Exiting."
+    exit 0
+  fi
 else
-  echo "ocm-env is already configured."
+  init_new_config
 fi
 
-echo "Creating symlink"
-ln -s "$(pwd)/ocm-container.sh" /usr/local/bin/ocm-env
+echo "Creating symlink for ocm-container binary"
+ln -sfn "$(pwd)/ocm-container.sh" /usr/local/bin/ocm-container
 
 echo
 echo "Tip: Many developers like to add the following alias:"
-echo "alias ocm-env-stg=\"OCM_URL=staging ocm-env\""
+echo "alias ocm-container-stg=\"OCM_URL=staging ocm-container\""
 
 echo
 echo
-echo "ocm-env configuration can be customized by editing ${CONFIG_DIR}/env.source"
+echo "ocm-container configuration can be customized by editing ${CONFIG_DIR}/env.source"
+
 
 

--- a/init.sh
+++ b/init.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+cd $(dirname $0)
+
+CONFIG_DIR=${HOME}/.config/ocm-env
+mkdir -p ${CONFIG_DIR}
+
+if [ ! -f ${CONFIG_DIR}/env.source ]
+then
+  echo "Initializing Default Configuration"
+  cp env.source.sample ${CONFIG_DIR}/env.source
+else
+  echo "ocm-env is already configured."
+fi
+
+echo "Creating symlink"
+ln -s "$(pwd)/ocm-container.sh" /usr/local/bin/ocm-env
+
+echo
+echo "Tip: Many developers like to add the following alias:"
+echo "alias ocm-env-stg=\"OCM_URL=staging ocm-env\""
+
+echo
+echo
+echo "ocm-env configuration can be customized by editing ${CONFIG_DIR}/env.source"
+
+

--- a/ocm-container.sh
+++ b/ocm-container.sh
@@ -5,16 +5,16 @@ cd $(dirname $0)
 
 ### Load config
 CONFIG_DIR=${HOME}/.config/ocm-container
-export OCM_ENV_CONFIGFILE="$CONFIG_DIR/env.source"
+export OCM_CONTAINER_CONFIGFILE="$CONFIG_DIR/env.source"
 
-if [ ! -f ${OCM_ENV_CONFIGFILE} ]; then
-    echo "Cannot find config file at $OCM_CONTAINER_CONFIG";
+if [ ! -f ${OCM_CONTAINER_CONFIGFILE} ]; then
+    echo "Cannot find config file at $OCM_CONTAINER_CONFIGFILE";
     echo "Run the init.sh file to create one."
     echo "exiting"
     exit 1;
 fi
 
-source ${OCM_ENV_CONFIGFILE}
+source ${OCM_CONTAINER_CONFIGFILE}
 
 ### start container
 ${CONTAINER_SUBSYS} run -it --rm --privileged \

--- a/ocm-container.sh
+++ b/ocm-container.sh
@@ -4,7 +4,7 @@
 cd $(dirname $0)
 
 ### Load config
-CONFIG_DIR=${HOME}/.config/ocm-env
+CONFIG_DIR=${HOME}/.config/ocm-container
 export OCM_ENV_CONFIGFILE="$CONFIG_DIR/env.source"
 
 if [ ! -f ${OCM_ENV_CONFIGFILE} ]; then
@@ -20,7 +20,7 @@ source ${OCM_ENV_CONFIGFILE}
 ${CONTAINER_SUBSYS} run -it --rm --privileged \
 -e "OCM_URL=${OCM_URL}" \
 -e "SSH_AUTH_SOCK=/tmp/ssh.sock" \
--v ${CONFIG_DIR}:/root/.config/ocm-env \
+-v ${CONFIG_DIR}:/root/.config/ocm-container \
 -v ${SSH_AUTH_SOCK}:/tmp/ssh.sock \
 -v ${HOME}/.ssh:/root/.ssh \
 -v ${HOME}/.aws/credentials:/root/.aws/credentials \

--- a/ocm-container.sh
+++ b/ocm-container.sh
@@ -4,23 +4,24 @@
 cd $(dirname $0)
 
 ### Load config
-export OCM_CONTAINER_CONFIG="./env.source"
+CONFIG_DIR=${HOME}/.config/ocm-env
+export OCM_ENV_CONFIGFILE="$CONFIG_DIR/env.source"
 
-export CONTAINER_SUBSYS="sudo docker"
-
-if [ ! -f ${OCM_CONTAINER_CONFIG} ]; then
-    echo "Cannot find config file, exiting";
+if [ ! -f ${OCM_ENV_CONFIGFILE} ]; then
+    echo "Cannot find config file at $OCM_CONTAINER_CONFIG";
+    echo "Run the init.sh file to create one."
+    echo "exiting"
     exit 1;
 fi
 
-source ${OCM_CONTAINER_CONFIG}
+source ${OCM_ENV_CONFIGFILE}
 
 ### start container
 ${CONTAINER_SUBSYS} run -it --rm --privileged \
 -e "OCM_URL=${OCM_URL}" \
 -e "SSH_AUTH_SOCK=/tmp/ssh.sock" \
--v $(pwd)/env.source:/root/env.source \
+-v ${CONFIG_DIR}:/root/.config/ocm-env \
 -v ${SSH_AUTH_SOCK}:/tmp/ssh.sock \
 -v ${HOME}/.ssh:/root/.ssh \
-ocm-container ${SSH_AUTH_ENABLE} /bin/bash ## -c "/container-setup/login.sh $@ && /container-setup/bash-ps1-wrap.sh"
-
+-v ${HOME}/.aws/credentials:/root/.aws/credentials \
+ocm-container ${SSH_AUTH_ENABLE} /bin/bash 


### PR DESCRIPTION
This should simplify the initialization process for ocm-container as
well as add the ability for a user to further customize their
environment through the config file.

The main benefit of moving the config file to a neutral location is that
the config file can now be stored in a users' dotfiles and however they
have those set to be backed up, instead of being stored within the main
repo.