### PR TITLE
Adds ssh-agent fix for macos

### DIFF
--- a/ocm-container.sh
+++ b/ocm-container.sh
@@ -16,12 +16,21 @@ fi
 
 source ${OCM_CONTAINER_CONFIGFILE}
 
+operating_system=`uname`
+
+SSH_AGENT_MOUNT="-v ${SSH_AUTH_SOCK}:/tmp/ssh.sock"
+
+if [[ "$operating_system" == "Darwin" ]]
+then
+  SSH_AGENT_MOUNT="--mount type=bind,src=/run/host-services/ssh-auth.sock,target=/tmp/ssh.sock"
+fi
+
 ### start container
 ${CONTAINER_SUBSYS} run -it --rm --privileged \
 -e "OCM_URL=${OCM_URL}" \
 -e "SSH_AUTH_SOCK=/tmp/ssh.sock" \
 -v ${CONFIG_DIR}:/root/.config/ocm-container \
--v ${SSH_AUTH_SOCK}:/tmp/ssh.sock \
+${SSH_AGENT_MOUNT} \
 -v ${HOME}/.ssh:/root/.ssh \
 -v ${HOME}/.aws/credentials:/root/.aws/credentials \
 ocm-container ${SSH_AUTH_ENABLE} /bin/bash 


### PR DESCRIPTION
Please test on machines that are not mine, preferrably both on Linux and MacOS :)

Source for fix: https://docs.docker.com/docker-for-mac/osxfs/#ssh-agent-forwarding - apparently it's a magic file path that Docker For Mac takes care of for you.

Should be able to test by just running `ssh-add -l` in the container and verifying that you can see your keys.