### PR TITLE
Correct invalid ocm completion install cmd

### DIFF
--- a/container-setup/install/install-ocm.sh
+++ b/container-setup/install/install-ocm.sh
@@ -10,4 +10,4 @@ source /container-setup/install/helpers.sh
 
 remove_coloring go get -v -u github.com/openshift-online/ocm-cli/cmd/ocm;
 ln -s /root/go/bin/ocm /usr/local/bin/ocm;
-ocm completion bash > /etc/bash_completion.d/ocm
+ocm completion > /etc/bash_completion.d/ocm


### PR DESCRIPTION
When attempting to build the container it fails when running the `ocm completion bash` command.

I verified via a latest source build of OCM that this is indeed invalid. For OCM (right now at least) it's just `ocm completion`.
