### PR TITLE
Replaces `moactl` binary references with `rosa`

### DIFF
--- a/container-setup/install/install-moactl.sh
+++ b/container-setup/install/install-moactl.sh
@@ -21,7 +21,7 @@ LATEST_TAG=$(git describe --tags);
 git checkout ${LATEST_TAG};
 
 make install;
-ln -s /root/go/bin/moactl /usr/local/bin/moactl;
-moactl completion bash >  /etc/bash_completion.d/moactl
+ln -s /root/go/bin/rosa /usr/local/bin/rosa;
+rosa completion bash >  /etc/bash_completion.d/rosa
 popd;
 popd;


### PR DESCRIPTION
MOA/AMRO has been renamed ROSA, and the moactl binary is now generated with the name `rosa`.

Replaced instances of `moactl` with `rosa` where appropriate to fix build errors resulting from the name change.

Signed-off-by: Christopher Collins <collins.christopher@gmail.com>

k# Please enter the commit message for your changes. Lines starting