### PR TITLE
Use readonly volumes explicitly while running the container

### DIFF
--- a/ocm-container.sh
+++ b/ocm-container.sh
@@ -18,20 +18,20 @@ source ${OCM_CONTAINER_CONFIGFILE}
 
 operating_system=`uname`
 
-SSH_AGENT_MOUNT="-v ${SSH_AUTH_SOCK}:/tmp/ssh.sock"
+SSH_AGENT_MOUNT="-v ${SSH_AUTH_SOCK}:/tmp/ssh.sock:ro"
 
 if [[ "$operating_system" == "Darwin" ]]
 then
-  SSH_AGENT_MOUNT="--mount type=bind,src=/run/host-services/ssh-auth.sock,target=/tmp/ssh.sock"
+  SSH_AGENT_MOUNT="--mount type=bind,src=/run/host-services/ssh-auth.sock,target=/tmp/ssh.sock,readonly"
 fi
 
 ### start container
 ${CONTAINER_SUBSYS} run -it --rm --privileged \
 -e "OCM_URL=${OCM_URL}" \
 -e "SSH_AUTH_SOCK=/tmp/ssh.sock" \
--v ${CONFIG_DIR}:/root/.config/ocm-container \
+-v ${CONFIG_DIR}:/root/.config/ocm-container:ro \
 ${SSH_AGENT_MOUNT} \
--v ${HOME}/.ssh:/root/.ssh \
--v ${HOME}/.aws/credentials:/root/.aws/credentials \
--v ${HOME}/.aws/config:/root/.aws/config \
+-v ${HOME}/.ssh:/root/.ssh:ro \
+-v ${HOME}/.aws/credentials:/root/.aws/credentials:ro \
+-v ${HOME}/.aws/config:/root/.aws/config:ro \
 ocm-container ${SSH_AUTH_ENABLE} /bin/bash 


### PR DESCRIPTION
I saw that we only need read access on the volume mounts. from the readme.md:

```
Does not mount any host filesystem objects as read/write, only uses read-only mounts.
```

However, the default mount is read/Write:

```
podman inspect 382b8a3a2483 | grep -A30 Mounts
        "Mounts": [
            {
                "Type": "bind",
                "Name": "",
                "Source": "/home/kramraja/.aws/credentials",
                "Destination": "/root/.aws/credentials",
                "Driver": "",
                "Mode": "",
                "Options": [
                    "rbind"
                ],
                "RW": true,
                "Propagation": "rprivate"
            },
            {
                "Type": "bind",
                "Name": "",
                "Source": "/home/kramraja/.aws/config",
                "Destination": "/root/.aws/config",
                "Driver": "",
                "Mode": "",
                "Options": [
                    "rbind"
                ],
                "RW": true,
                "Propagation": "rprivate"
            },
```

This PR fixes this by explicitly mounting in readonly mode while running/starting a container. 