### PR TITLE
Adds ability to pass in extra options on container startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ Related tools added to image:
 ```
 ocm-container
 ```
+With launch options:
+```
+OCM_CONTAINER_LAUNCH_OPTS="-v ~/work/myproject:/root/myproject" ocm-container
+```
+
+Launch options provide you a way to add other volumes, add environment variables, or anything else you would need to do to run ocm-container the way you want to.
 
 ## Example:
 

--- a/ocm-container.sh
+++ b/ocm-container.sh
@@ -34,5 +34,5 @@ ${SSH_AGENT_MOUNT} \
 -v ${HOME}/.ssh:/root/.ssh:ro \
 -v ${HOME}/.aws/credentials:/root/.aws/credentials:ro \
 -v ${HOME}/.aws/config:/root/.aws/config:ro \
-${EXTRA_CONTAINER_OPTS} \
+${OCM_CONTAINER_LAUNCH_OPTS} \
 ocm-container ${SSH_AUTH_ENABLE} /bin/bash 

--- a/ocm-container.sh
+++ b/ocm-container.sh
@@ -34,4 +34,5 @@ ${SSH_AGENT_MOUNT} \
 -v ${HOME}/.ssh:/root/.ssh:ro \
 -v ${HOME}/.aws/credentials:/root/.aws/credentials:ro \
 -v ${HOME}/.aws/config:/root/.aws/config:ro \
+${EXTRA_CONTAINER_OPTS} \
 ocm-container ${SSH_AUTH_ENABLE} /bin/bash 


### PR DESCRIPTION
Adds this parameter in order to pass in extra options on container startup without having to edit the ocm-container startup script directly.

In my case, I'm using it in order to pass in a volume containing a script I'm writing that has to be run on multiple clusters.

USAGE: `OCM_CONTAINER_LAUNCH_OPTS="-v ${HOME}/path/to/script:/root/script.sh" ocm-container`