### PR TITLE
adds bashrc.d convention; login alias and elevate function

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,7 @@ RUN ./install/install-osdctl.sh
 RUN ./install/install-velero.sh
 RUN ./install/install-utils.sh
 
+RUN mv /container-setup/install/bashrc.d/ /root/bashrc.d/
 RUN cat /container-setup/install/bashrc_supplement.sh >> ~/.bashrc
 
 RUN rm -rf /container-setup

--- a/container-setup/install/bashrc.d/alias_login_sh.bashrc
+++ b/container-setup/install/bashrc.d/alias_login_sh.bashrc
@@ -1,0 +1,1 @@
+alias login="/root/utils/login.sh"

--- a/container-setup/install/bashrc.d/function_elevate_privileges.bashrc
+++ b/container-setup/install/bashrc.d/function_elevate_privileges.bashrc
@@ -1,0 +1,3 @@
+function elevate() {
+  oc adm groups add-users osd-sre-cluster-admins $(oc whoami)
+}

--- a/container-setup/install/bashrc_supplement.sh
+++ b/container-setup/install/bashrc_supplement.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+for FILE in ${HOME}/bashrc.d/*.bashrc ; do source ${FILE} ; done
+
 source /usr/local/kube_ps1/kube-ps1.sh
 
 ## Set Defaults


### PR DESCRIPTION
* Adds "${HOME}/bashrc.d" directory that works as one would expect.
* Adds a function to elevate privileges as documented in the manage-privileges SOP
* Aliases "login" to "login.sh" to prevent accidental invocation of /usr/bin/login (and save three characters)

Signed-off-by: Christopher Collins <collins.christopher@gmail.com>